### PR TITLE
Add `top_k` and `top_p` to shortfin kwargs

### DIFF
--- a/examples/frontend_language/quick_start/shortfin_example_chat.py
+++ b/examples/frontend_language/quick_start/shortfin_example_chat.py
@@ -19,9 +19,9 @@ import sglang as sgl
 def multi_turn_question(s, question_1, question_2):
     s += sgl.system("You are a helpful assistant.")
     s += sgl.user(question_1)
-    s += sgl.assistant(sgl.gen("answer_1", max_tokens=256))
+    s += sgl.assistant(sgl.gen("answer_1", max_tokens=256, top_p=0.95))
     s += sgl.user(question_2)
-    s += sgl.assistant(sgl.gen("answer_2", max_tokens=256))
+    s += sgl.assistant(sgl.gen("answer_2", max_tokens=256, top_p=0.95))
 
 
 @sgl.function

--- a/python/sglang/lang/ir.py
+++ b/python/sglang/lang/ir.py
@@ -131,6 +131,18 @@ class SglSamplingParams:
             "max_completion_tokens": self.max_new_tokens,
             "temperature": self.temperature,
         }
+
+        top_p = self.top_p
+        if top_p == 1.0:
+            top_p = None
+
+        top_k = self.top_k
+        if top_k == -1:
+            top_k = None
+
+        kwargs["sampling_params"]["top_p"] = top_p
+        kwargs["sampling_params"]["top_k"] = top_k
+
         return kwargs
 
     def to_srt_kwargs(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This PR adds support for the `top_k` and `top_p` args in requests to the Shortfin backend.

## Modifications

Pretty simple change here. Handles converting the sglang defaults to the shortfin defaults. Otherwise, just add the value to the `sampling_params`.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html).
